### PR TITLE
rm custom shebang, didnt work with env

### DIFF
--- a/models/lstm_model.py
+++ b/models/lstm_model.py
@@ -1,4 +1,4 @@
-#!/home/blyaat/Desktop/ian/GitHub/BuSsi_Bot/my_env/bin python3
+#!/usr/bin/env python3
 
 import sys
 from pathlib import Path

--- a/utils/preprocess.py
+++ b/utils/preprocess.py
@@ -1,4 +1,4 @@
-#!/home/blyaat/Desktop/ian/GitHub/BuSsi_Bot/my_env/bin python3
+#!/usr/bin/env python3
 
 import numpy as np
 import os


### PR DESCRIPTION
As we need to work with numpy=1.26.4-1 to use np.unicode_ and it support was removed on numpy=>2.0 to np.str_. It creates an errror during the LSTM Training. Installing a custom env for python3.11 to use older versions of numpy didnt do the trick. Going back to normal shebang.